### PR TITLE
Update tests to NET Core 2.1 and Test.Sdk 16.11.0.

### DIFF
--- a/source/OfxSharp.NETCore.Tests/OfxSharp.NETCore.Tests.csproj
+++ b/source/OfxSharp.NETCore.Tests/OfxSharp.NETCore.Tests.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.6.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>
 


### PR DESCRIPTION
I found this was needed to get "dotnet test" to execute tests from command line